### PR TITLE
Add CPU temperature reader

### DIFF
--- a/app/src/main/java/com/smartsecurity/edge/CpuTempReader.kt
+++ b/app/src/main/java/com/smartsecurity/edge/CpuTempReader.kt
@@ -1,0 +1,64 @@
+package com.smartsecurity.edge
+
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.BatteryManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import java.io.File
+
+/**
+ * Utility for reading device temperature without requiring privileged permissions.
+ */
+object CpuTempReader {
+
+    /**
+     * Reads CPU temperature in Celsius or null if unavailable.
+     */
+    fun readCpuTempC(): Float? = runBlocking {
+        scanThermalZones()
+    }
+
+    /**
+     * Reads battery temperature via [BatteryManager] fallback.
+     */
+    fun readBatteryTempC(context: Context): Float? {
+        val bm = context.getSystemService(Context.BATTERY_SERVICE) as? BatteryManager
+        val fromProp = bm?.getIntProperty(BatteryManager.BATTERY_PROPERTY_TEMPERATURE)
+        if (fromProp != null && fromProp != Int.MIN_VALUE) {
+            val temp = fromProp / 10f
+            if (temp in -40f..200f) return temp
+        }
+        val intent = context.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+        val extra = intent?.getIntExtra(BatteryManager.EXTRA_TEMPERATURE, Int.MIN_VALUE)
+        if (extra != null && extra != Int.MIN_VALUE) {
+            val temp = extra / 10f
+            if (temp in -40f..200f) return temp
+        }
+        return null
+    }
+
+    private suspend fun scanThermalZones(): Float? = withContext(Dispatchers.IO) {
+        val roots = listOf(
+            File("/sys/class/thermal"),
+            File("/sys/devices/virtual/thermal")
+        )
+        for (root in roots) {
+            if (!root.isDirectory) continue
+            root.listFiles { file -> file.name.startsWith("thermal_zone") }?.forEach { zone ->
+                val typeFile = File(zone, "type")
+                val type = runCatching { typeFile.readText().trim() }.getOrNull()?.lowercase()
+                if (type != null && ("cpu" in type || "soc" in type)) {
+                    val tempFile = File(zone, "temp")
+                    val raw = runCatching { tempFile.readText().trim() }.getOrNull()
+                    val value = raw?.toFloatOrNull() ?: return@forEach
+                    val c = if (value > 150) value / 1000f else value
+                    if (c in -40f..200f) return@withContext c
+                }
+            }
+        }
+        null
+    }
+}

--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -18,6 +18,9 @@ android {
 }
 
 dependencies {
+    implementation(project(":app"))
+
     testImplementation(kotlin("test"))
     testImplementation("junit:junit:4.13.2")
+    testImplementation("org.robolectric:robolectric:4.10.3")
 }

--- a/tests/src/main/java/com/smartsecurity/tests/CpuTempReaderTest.kt
+++ b/tests/src/main/java/com/smartsecurity/tests/CpuTempReaderTest.kt
@@ -1,0 +1,33 @@
+package com.smartsecurity.tests
+
+import android.content.Context
+import android.os.BatteryManager
+import androidx.test.core.app.ApplicationProvider
+import com.smartsecurity.edge.CpuTempReader
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowBatteryManager
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class CpuTempReaderTest {
+    @Test
+    fun readBatteryTemp_returnsValue() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val bm = context.getSystemService(Context.BATTERY_SERVICE) as BatteryManager
+        val shadowBm = shadowOf(bm) as ShadowBatteryManager
+        shadowBm.setIntProperty(BatteryManager.BATTERY_PROPERTY_TEMPERATURE, 370)
+
+        val temp = CpuTempReader.readBatteryTempC(context)
+        assertNotNull(temp)
+    }
+
+    @Test
+    fun readCpuTemp_doesNotThrow() {
+        CpuTempReader.readCpuTempC()
+    }
+}


### PR DESCRIPTION
## Summary
- provide CpuTempReader utility in app module
- allow reading CPU thermal zones and battery temperature
- configure tests module for Robolectric
- test battery temperature reading with Robolectric

## Testing
- `./gradlew test --no-daemon` *(fails: Gradle wrapper jar missing)*

------
https://chatgpt.com/codex/tasks/task_e_6851631f8b008325a1e4757db6831acb